### PR TITLE
feat: Add progress bar to backtester

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -69,3 +69,4 @@ wandb
 pettingzoo
 supersuit
 shap
+tqdm

--- a/src/execution/backtester.py
+++ b/src/execution/backtester.py
@@ -6,6 +6,7 @@ import pandas as pd
 from datetime import datetime, time, timedelta
 import random
 import os
+from tqdm import tqdm
 
 # This backtester is designed to match run.py expectations and integrate with IntradayStrategy.evaluate_entry
 # It supports:
@@ -144,7 +145,7 @@ class Backtester:
         daily_bias_map = self._compute_daily_bias()
 
         # Iterate day-by-day
-        for day, day_df in df.groupby(df.index.date):
+        for day, day_df in tqdm(df.groupby(df.index.date), desc="Backtesting"):
             # reset daily loss
             self.daily_pnl = 0.0
             self.current_day = day


### PR DESCRIPTION
This commit adds a progress bar to the backtester using the `tqdm` library. This provides a visual indication of the backtest's progress, which is especially useful for long-running backtests.